### PR TITLE
nicer module name detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -786,8 +786,7 @@
     "path-parse": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-      "dev": true
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
     "path-platform": {
       "version": "0.11.15",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "JSONStream": "^1.3.1",
     "magic-string": "^0.21.3",
+    "path-parse": "^1.0.5",
     "through2": "^2.0.3",
     "transform-ast": "^2.1.0",
     "umd": "^3.0.1"

--- a/test/bare-module/expected.js
+++ b/test/bare-module/expected.js
@@ -1,18 +1,18 @@
 (function(){
-var __module_2 = { exports: {} };
+var _$wrapped_2 = { exports: {} };
 (function (module) {
   module.exports = 'whatever'
-})(__module_2)
+})(_$wrapped_2)
 
-__module_2 = __module_2.exports
-var __module_1 = { exports: {} };
-__module_2
+_$wrapped_2 = _$wrapped_2.exports
+var _$app_1 = { exports: {} };
+_$wrapped_2
 
-if ("object" === 'object' && __module_1.exports) {
+if ("object" === 'object' && _$app_1.exports) {
   console.log('commonjs')
 }
 
-__module_1 = __module_1.exports
-module.exports = __module_1;
+_$app_1 = _$app_1.exports
+module.exports = _$app_1;
 
 }());

--- a/test/comment/expected.js
+++ b/test/comment/expected.js
@@ -1,8 +1,8 @@
 (function(){
-var __module_2 = 10 //
+var _$other_2 = 10 //
 
-var __module_1 = {};
-var __other_1 = __module_2
+var _$app_1 = {};
+var __other_1 = _$other_2
 
 //
 

--- a/test/dedupe/expected.js
+++ b/test/dedupe/expected.js
@@ -1,14 +1,14 @@
 (function(){
-var __module_2 = 'a/xyz.js'
+var _$xyz_2 = 'a/xyz.js'
 
-var __module_1 = __module_2
+var _$a_1 = _$xyz_2
 
-var __module_5 = 'b/xyz.js'
+var _$xyz_5 = 'b/xyz.js'
 
-var __module_4 = __module_5
+var _$b_4 = _$xyz_5
 
-var __module_3 = {};
-var __a_3 = __module_1
-var __b_3 = __module_4
+var _$app_3 = {};
+var __a_3 = _$a_1
+var __b_3 = _$b_4
 
 }());

--- a/test/eager-cycles/expected.js
+++ b/test/eager-cycles/expected.js
@@ -1,25 +1,25 @@
 (function(){
-var __cycle = function r(o){var t=r.r;if(t[o])return t[o].exports;if(r.hasOwnProperty(o))return t[o]={exports:{}},r[o](t[o],t[o].exports),t[o].exports;throw new Error("Cannot find module #"+o)}; __cycle.r = {};
-__cycle[1] = (function (module, exports) {
-exports.b = __module_3
-exports.c = __cycle(4)
+var _$cycle = function r(o){var t=r.r;if(t[o])return t[o].exports;if(r.hasOwnProperty(o))return t[o]={exports:{}},r[o](t[o],t[o].exports),t[o].exports;throw new Error("Cannot find module #"+o)}; _$cycle.r = {};
+_$cycle[1] = (function (module, exports) {
+exports.b = _$b_3
+exports.c = _$cycle(4)
 
 });
-__cycle[4] = (function (module, exports) {
-module.exports = 10 + __cycle(1).b
+_$cycle[4] = (function (module, exports) {
+module.exports = 10 + _$cycle(1).b
 
 });
-var __module_3 = 10
+var _$b_3 = 10
 
-var __module_5 = 'hello'
+var _$d_5 = 'hello'
 
-var __module_6 = 'world'
+var _$e_6 = 'world'
 
-var __module_2 = {};
+var _$app_2 = {};
 console.log({
-  d: __module_5,
-  a: __cycle(1),
-  e: __module_6
+  d: _$d_5,
+  a: _$cycle(1),
+  e: _$e_6
 })
 
 }());

--- a/test/exports-name/expected.js
+++ b/test/exports-name/expected.js
@@ -1,17 +1,17 @@
 (function(){
-var __ThisIsAClass_2 = class ThisIsAClass {}
+var _$ThisIsAClass_2 = class ThisIsAClass {}
 
-var __thisIsAFunction_3 = function thisIsAFunction () {}
+var _$thisIsAFunction_3 = function thisIsAFunction () {}
 
-var __thisIsAReference_4 = __thisIsAReference_4
+var _$thisIsAReference_4 = __thisIsAReference_4
 
 function __thisIsAReference_4 () {}
 
-var __module_1 = {};
+var _$app_1 = {};
 console.log(
-  __thisIsAFunction_3.name,
-  __ThisIsAClass_2.name,
-  function () { __thisIsAReference_4 }.toString()
+  _$thisIsAFunction_3.name,
+  _$ThisIsAClass_2.name,
+  function () { _$thisIsAReference_4 }.toString()
 )
 
 }());

--- a/test/globals/expected.js
+++ b/test/globals/expected.js
@@ -1,19 +1,19 @@
 (function(){
-var __module_2 = {};
+var _$fn_2 = {};
 function __globalFunction_2 () {
   var globalFunction = null
 }
 
-var __module_3 = {};
+var _$other_3 = {};
 var __somevar_3 = 1
 console.log(__somevar_3)
 
-var __module_1 = {};
+var _$app_1 = {};
 var __somevar_1 = 0
 
-__module_3
+_$other_3
 console.log(__somevar_1)
 
-__module_2
+_$fn_2
 
 }());

--- a/test/lazy-cycles/expected.js
+++ b/test/lazy-cycles/expected.js
@@ -1,21 +1,21 @@
 (function(){
-var __cycle = function r(o){var t=r.r;if(t[o])return t[o].exports;if(r.hasOwnProperty(o))return t[o]={exports:{}},r[o](t[o],t[o].exports),t[o].exports;throw new Error("Cannot find module #"+o)}; __cycle.r = {};
-__cycle[1] = (function (module, exports) {
-var b = __cycle(3)
+var _$cycle = function r(o){var t=r.r;if(t[o])return t[o].exports;if(r.hasOwnProperty(o))return t[o]={exports:{}},r[o](t[o],t[o].exports),t[o].exports;throw new Error("Cannot find module #"+o)}; _$cycle.r = {};
+_$cycle[1] = (function (module, exports) {
+var b = _$cycle(3)
 module.exports = function () {
   return b()
 }
 
 });
-__cycle[3] = (function (module, exports) {
+_$cycle[3] = (function (module, exports) {
 module.exports = function () {
-  return __cycle(1).toString()
+  return _$cycle(1).toString()
 }
 
 });
-var __module_2 = {};
+var _$app_2 = {};
 console.log(
-  __cycle(1)()
+  _$cycle(1)()
 )
 
 }());

--- a/test/set-exports/expected.js
+++ b/test/set-exports/expected.js
@@ -1,28 +1,28 @@
 (function(){
-var __module_2 = {};
-__module_2 = __module_2 = 2
+var _$both_2 = {};
+_$both_2 = _$both_2 = 2
 
-var __module_3 = {};
-__module_3 = 3
+var _$exportsOnly_3 = {};
+_$exportsOnly_3 = 3
 
-var __module_4 = { exports: {} };
+var _$freeModule_4 = { exports: {} };
 var __something_4 = function () {
-  return __module_4
+  return _$freeModule_4
 }
 __something_4().exports = 5
 
-__module_4 = __module_4.exports
-var __module_5 = 1
+_$freeModule_4 = _$freeModule_4.exports
+var _$moduleExports_5 = 1
 
-var __module_6 = 4
+var _$quoted_6 = 4
 
-var __module_1 = {};
-__module_1.moduleExports = __module_5
-__module_1.both = __module_2
-__module_1.exportsOnly = __module_3
-__module_1.quoted = __module_6
-__module_1.free = __module_4
+var _$app_1 = {};
+_$app_1.moduleExports = _$moduleExports_5
+_$app_1.both = _$both_2
+_$app_1.exportsOnly = _$exportsOnly_3
+_$app_1.quoted = _$quoted_6
+_$app_1.free = _$freeModule_4
 
-module.exports = __module_1;
+module.exports = _$app_1;
 
 }());

--- a/test/shorthand/expected.js
+++ b/test/shorthand/expected.js
@@ -1,10 +1,10 @@
 (function(){
-var __module_1 = {};
+var _$app_1 = {};
 var __globalVar_1 = 0
 
 function __setExports_1 (argument) {
   var localVar = 1
-  __module_1 = {
+  _$app_1 = {
     globalVar: __globalVar_1,
     localVar,
     argument
@@ -13,6 +13,6 @@ function __setExports_1 (argument) {
 
 __setExports_1(10)
 
-module.exports = __module_1;
+module.exports = _$app_1;
 
 }());

--- a/test/simplify/expected.js
+++ b/test/simplify/expected.js
@@ -1,10 +1,10 @@
 (function(){
-var __module_2 = 'hello'
+var _$hello_2 = 'hello'
 
-var __module_3 = {};
-var __world_3 = __module_3 = 'world'
+var _$world_3 = {};
+var __world_3 = _$world_3 = 'world'
 
-var __module_1 = {};
-console.log(__module_2, __module_3)
+var _$app_1 = {};
+console.log(_$hello_2, _$world_3)
 
 }());

--- a/test/source-map/expected.js
+++ b/test/source-map/expected.js
@@ -1,9 +1,9 @@
 (function(){
-var __module_2 = 10
+var _$b_2 = 10
 
-var __module_1 = __module_2
+var _$app_1 = _$b_2
 
-module.exports = __module_1;
+module.exports = _$app_1;
 
 }());
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjpudWxsLCJzb3VyY2VzIjpbInRlc3Qvc291cmNlLW1hcC9iLmpzIiwidGVzdC9zb3VyY2UtbWFwL2FwcC5qcyJdLCJzb3VyY2VzQ29udGVudCI6WyJtb2R1bGUuZXhwb3J0cyA9IDEwXG4iLCJtb2R1bGUuZXhwb3J0cyA9IHJlcXVpcmUoJy4vYicpXG4iXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IjtBQUFBLGNBQWM7O0FDQWQsY0FBYyxHQUFHLFVBQWM7Ozs7OzsifQ==
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjpudWxsLCJzb3VyY2VzIjpbInRlc3Qvc291cmNlLW1hcC9iLmpzIiwidGVzdC9zb3VyY2UtbWFwL2FwcC5qcyJdLCJzb3VyY2VzQ29udGVudCI6WyJtb2R1bGUuZXhwb3J0cyA9IDEwXG4iLCJtb2R1bGUuZXhwb3J0cyA9IHJlcXVpcmUoJy4vYicpXG4iXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IjtBQUFBLFNBQWM7O0FDQWQsV0FBYyxHQUFHLEtBQWM7Ozs7OzsifQ==

--- a/test/standalone/expected.js
+++ b/test/standalone/expected.js
@@ -1,16 +1,16 @@
 (function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.modulename = f()}})(function(){var define,module,exports;
-var __a_1 = function a() {
+var _$a_1 = function a() {
   return 'A'
 }
 
-var __b_3 = function b() {
+var _$b_3 = function b() {
   return 'B'
 }
 
-var __module_2 = {};
-__module_2.a = __a_1
-__module_2.b = __b_3
+var _$app_2 = {};
+_$app_2.a = _$a_1
+_$app_2.b = _$b_3
 
-return __module_2;
+return _$app_2;
 
 });

--- a/test/variable/expected.js
+++ b/test/variable/expected.js
@@ -1,16 +1,16 @@
 (function(){
-var __module_2 = function (module) {
+var _$param_2 = function (module) {
   return { exports: module }
 }
 
-var __module_1 = {};
-__module_1.param = __module_2
-__module_1.something = function () {
+var _$app_1 = {};
+_$app_1.param = _$param_2
+_$app_1.something = function () {
   var exports = {}
-  exports.something = __module_2
+  exports.something = _$param_2
   return exports
 }
 
-module.exports = __module_1;
+module.exports = _$app_1;
 
 }());


### PR DESCRIPTION
uses filenames to try to get more debuggable module variable names.

module-related variables now use a _$ prefix, while top-level variables
inside modules are still rewritten to __. this prevents conflicts when
eg. a module's file name is similar to a variable name in the file.