### PR TITLE
Only rename top-level variables if they conflict

### DIFF
--- a/test/destructure/expected.js
+++ b/test/destructure/expected.js
@@ -1,7 +1,8 @@
 (function(){
-var _$greeting_2 = {};
-_$greeting_2.hello = 'hello'
-_$greeting_2.world = 'everyone'
+var hello = 'hello'
+var world = 'everyone'
+
+var _$greeting_2 = { hello, world }
 
 var _$app_1 = {};
 var {

--- a/test/destructure/greeting.js
+++ b/test/destructure/greeting.js
@@ -1,2 +1,4 @@
-exports.hello = 'hello'
-exports.world = 'everyone'
+var hello = 'hello'
+var world = 'everyone'
+
+module.exports = { hello, world }

--- a/test/dynamic-require/expected.js
+++ b/test/dynamic-require/expected.js
@@ -1,9 +1,9 @@
 (function(){
 var _$app_1 = {};
-var __value_1 = getSomeValueSomehow()
+var value = getSomeValueSomehow()
 
 require('hello/' + 'world')
 
-require(__value_1)
+require(value)
 
 }());

--- a/test/exports-name/expected.js
+++ b/test/exports-name/expected.js
@@ -3,9 +3,9 @@ var _$ThisIsAClass_2 = class ThisIsAClass {}
 
 var _$thisIsAFunction_3 = function thisIsAFunction () {}
 
-var _$thisIsAReference_4 = __thisIsAReference_4
+var _$thisIsAReference_4 = thisIsAReference
 
-function __thisIsAReference_4 () {}
+function thisIsAReference () {}
 
 var _$app_1 = {};
 console.log(

--- a/test/globals/expected.js
+++ b/test/globals/expected.js
@@ -1,13 +1,17 @@
 (function(){
 var _$fn_2 = {};
-function __globalFunction_2 () {
+function globalFunction () {
   var globalFunction = null
   !function globalFunction () { return null }()
 }
 
 var _$other_3 = {};
-var __somevar_3 = 1
-console.log(__somevar_3)
+var somevar = 1
+console.log(somevar)
+
+function __globalFunction_3 () {
+  function somevar () {}
+}
 
 var _$app_1 = {};
 var __somevar_1 = 0

--- a/test/globals/other.js
+++ b/test/globals/other.js
@@ -1,2 +1,6 @@
 var somevar = 1
 console.log(somevar)
+
+function globalFunction () {
+  function somevar () {}
+}

--- a/test/set-exports/expected.js
+++ b/test/set-exports/expected.js
@@ -6,10 +6,10 @@ var _$exportsOnly_3 = {};
 _$exportsOnly_3 = 3
 
 var _$freeModule_4 = { exports: {} };
-var __something_4 = function () {
+var something = function () {
   return _$freeModule_4
 }
-__something_4().exports = 5
+something().exports = 5
 
 _$freeModule_4 = _$freeModule_4.exports
 var _$moduleExports_5 = 1

--- a/test/shorthand/app.js
+++ b/test/shorthand/app.js
@@ -1,9 +1,11 @@
 var globalVar = 0
+var importedModule = require('./importedModule')
 
 function setExports (argument) {
   var localVar = 1
   module.exports = {
     globalVar,
+    importedModule,
     localVar,
     argument
   }

--- a/test/shorthand/expected.js
+++ b/test/shorthand/expected.js
@@ -1,17 +1,23 @@
 (function(){
+var globalVar = 1
+
+var _$globalVar_2 = globalVar
+
 var _$app_1 = {};
 var __globalVar_1 = 0
+/* removed: var _$globalVar_2 = require('./importedModule') */
 
-function __setExports_1 (argument) {
+function setExports (argument) {
   var localVar = 1
   _$app_1 = {
     globalVar: __globalVar_1,
+    importedModule: _$globalVar_2,
     localVar,
     argument
   }
 }
 
-__setExports_1(10)
+setExports(10)
 
 module.exports = _$app_1;
 

--- a/test/shorthand/importedModule.js
+++ b/test/shorthand/importedModule.js
@@ -1,0 +1,3 @@
+var globalVar = 1
+
+module.exports = globalVar

--- a/test/simplify/expected.js
+++ b/test/simplify/expected.js
@@ -2,7 +2,7 @@
 var _$hello_2 = 'hello'
 
 var _$world_3 = {};
-var __world_3 = _$world_3 = 'world'
+var world = _$world_3 = 'world'
 
 var _$app_1 = {};
 /* removed: var _$hello_2 = require('./hello') */


### PR DESCRIPTION
There's no need to rename a variable in a module if there is no other variable of the same name in any other module. This patch only renames variables that have already been seen before. The first occurrence of a variable is not renamed.

```js
// a.js
var a = 'a'
// b.js
var a = 'b'
// app.js
require('./a')
require('./b')
var a = 'app'
```
→

```js
var __module_1 = {};
var a = 'a'
var __module_2 = {};
var __a_2 = 'b'
var __module_3 = {};
__module_1
__module_3
var __a_3 = 'app'
```