### PR TITLE
Simplify circular dependency runtime

### DIFF
--- a/cycleHelper.js
+++ b/cycleHelper.js
@@ -1,19 +1,15 @@
 /**
- * Helper used in the output bundle in case of dependency cycles.
- * Properties defined on the `factories` function are module factories, taking a
- * `module` and an `exports` argument.
- * The `.r` property of this function will contain the module cache.
+ * Helper used in the output bundle to resolve dependency cycles.
+ * This helper wraps a module factory and lazily executes it.
+ * Imports of a circular module will call the factory returned by this function.
  */
-function factories (id, resolved, exports) {
-  resolved = factories.r
-  if (resolved.hasOwnProperty(id)) {
-    return resolved[id].exports
+function cycleHelper (factory) {
+  var module
+  return function () {
+    if (!module) {
+      module = { exports: {} }
+      factory(module, module.exports)
+    }
+    return module.exports
   }
-  if (factories.hasOwnProperty(id)) {
-    exports = {}
-    resolved[id] = { exports: exports }
-    factories[id](resolved[id], exports)
-    return resolved[id].exports
-  }
-  throw Error('Cannot find module #' + id)
 }

--- a/test/eager-cycles/expected.js
+++ b/test/eager-cycles/expected.js
@@ -1,12 +1,12 @@
 (function(){
-var _$cycle = function r(o,t,n){if((t=r.r).hasOwnProperty(o))return t[o].exports;if(r.hasOwnProperty(o))return n={},t[o]={exports:n},r[o](t[o],n),t[o].exports;throw Error("Cannot find module #"+o)}; _$cycle.r = {};
-_$cycle[1] = (function (module, exports) {
+var _$cycle = function r(r){var t;return function(){return t||r(t={exports:{}},t.exports),t.exports}};
+var _$a_1 = _$cycle(function (module, exports) {
 exports.b = _$b_3
-exports.c = _$cycle(4)
+exports.c = _$c_4()
 
 });
-_$cycle[4] = (function (module, exports) {
-module.exports = 10 + _$cycle(1).b
+var _$c_4 = _$cycle(function (module, exports) {
+module.exports = 10 + _$a_1().b
 
 });
 var _$b_3 = 10
@@ -18,7 +18,7 @@ var _$e_6 = 'world'
 var _$app_2 = {};
 console.log({
   d: _$d_5,
-  a: _$cycle(1),
+  a: _$a_1(),
   e: _$e_6
 })
 

--- a/test/lazy-cycles/expected.js
+++ b/test/lazy-cycles/expected.js
@@ -1,21 +1,21 @@
 (function(){
-var _$cycle = function r(o,t,n){if((t=r.r).hasOwnProperty(o))return t[o].exports;if(r.hasOwnProperty(o))return n={},t[o]={exports:n},r[o](t[o],n),t[o].exports;throw Error("Cannot find module #"+o)}; _$cycle.r = {};
-_$cycle[1] = (function (module, exports) {
-var b = _$cycle(3)
+var _$cycle = function r(r){var t;return function(){return t||r(t={exports:{}},t.exports),t.exports}};
+var _$a_1 = _$cycle(function (module, exports) {
+var b = _$b_3()
 module.exports = function () {
   return b()
 }
 
 });
-_$cycle[3] = (function (module, exports) {
+var _$b_3 = _$cycle(function (module, exports) {
 module.exports = function () {
-  return _$cycle(1).toString()
+  return _$a_1().toString()
 }
 
 });
 var _$app_2 = {};
 console.log(
-  _$cycle(1)()
+  _$a_1()()
 )
 
 }());


### PR DESCRIPTION
Instead of a registry of circular dependencies, each module in a circular dependency chain is now wrapped in a small memoizing function. Uses of the module call that function. The module is evaluated the first time the function is called.