### PR TITLE
barebones module.parent implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,6 +163,12 @@ function rewriteModule (row, i, rows) {
       // rewrite `typeof module` to `"object"`
       if (node.parent.type === 'UnaryExpression' && node.parent.operator === 'typeof') {
         node.parent.edit.update('"object"')
+      } else if (isModuleParent(node.parent)) {
+        if (row.entry) {
+          node.parent.edit.update('null')
+        } else {
+          node.parent.edit.update('({})')
+        }
       } else {
         renameIdentifier(node, moduleBaseName)
       }
@@ -397,6 +403,12 @@ function isModuleExports (node) {
     node.object.type === 'Identifier' && node.object.name === 'module' &&
     (node.property.type === 'Identifier' && node.property.name === 'exports' ||
       node.property.type === 'Literal' && node.property.value === 'exports')
+}
+function isModuleParent (node) {
+  return node.type === 'MemberExpression' &&
+    node.object.type === 'Identifier' && node.object.name === 'module' &&
+    (node.property.type === 'Identifier' && node.property.name === 'parent' ||
+      node.property.type === 'Literal' && node.property.value === 'parent')
 }
 function isRequire (node) {
   return node.type === 'CallExpression' &&

--- a/test/module-parent/app.js
+++ b/test/module-parent/app.js
@@ -1,0 +1,5 @@
+require('./child')
+
+if (module.parent) {
+  throw Error('should be entry point')
+}

--- a/test/module-parent/child.js
+++ b/test/module-parent/child.js
@@ -1,0 +1,5 @@
+if (module.parent) {
+  module.exports = 'required'
+} else {
+  module.exports = 'entry point'
+}

--- a/test/module-parent/expected.js
+++ b/test/module-parent/expected.js
@@ -1,0 +1,18 @@
+(function(){
+var _$child_2 = { exports: {} };
+if (({})) {
+  _$child_2.exports = 'required'
+} else {
+  _$child_2.exports = 'entry point'
+}
+
+_$child_2 = _$child_2.exports
+var _$app_1 = { exports: {} };
+_$child_2
+
+if (null) {
+  throw Error('should be entry point')
+}
+
+_$app_1 = _$app_1.exports
+}());


### PR DESCRIPTION
if the module has a parent, rewrites `module.parent` to `{}`. else rewrites it to `null`.

this supports the case where `module.parent` is only used to check for whether the module is being invoked directly, or `require`d by some other module.

