### PR TITLE
Fix README example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ With the Node API:
 
 ```js
 var browserify = require('browserify')
-var packFlat = require('browser-pack-flat')
+var packFlat = require('browser-pack-flat/plugin')
 
 browserify({ entries: './src/app.js' })
   .plugin(packFlat, { /* options */ })


### PR DESCRIPTION
Should require the plugin, rather than the main export, as done in the tests.

See https://github.com/goto-bus-stop/browser-pack-flat/blob/c372967d06e8409ff1af868e4213c44736c10156/test/expose.js#L11