### PR TITLE
Fix module variable collisions with global variables used in later modules

### DIFF
--- a/test/colliding-unused/app.js
+++ b/test/colliding-unused/app.js
@@ -1,3 +1,5 @@
 var External = require('./other')
 
 External.boot()
+
+new URL('xyz')

--- a/test/colliding-unused/expected.js
+++ b/test/colliding-unused/expected.js
@@ -2,9 +2,14 @@
 // this `External` variable is probably defined by some other script on the page
 var _$External_2 = External
 
+// https://github.com/browserify/tinyify/issues/10
+var __URL_2 = null
+
 var _$app_1 = {};
 /* removed: var _$External_2 = require('./other') */;
 
 _$External_2.boot()
+
+new URL('xyz')
 
 }());

--- a/test/colliding-unused/other.js
+++ b/test/colliding-unused/other.js
@@ -1,2 +1,5 @@
 // this `External` variable is probably defined by some other script on the page
 module.exports = External
+
+// https://github.com/browserify/tinyify/issues/10
+var URL = null


### PR DESCRIPTION
The use of the global `URL` variable is in a "later" module in the stream, so the module that defines a variable by that name does not know it should be renamed.