### PR TITLE
evaluate conditional requires on-demand

### DIFF
--- a/test/exports-name/app.js
+++ b/test/exports-name/app.js
@@ -1,5 +1,5 @@
 console.log(
   require('./fn').name,
   require('./class').name,
-  function () { require('./var') }.toString()
+  require('./var').name
 )

--- a/test/exports-name/expected.js
+++ b/test/exports-name/expected.js
@@ -11,7 +11,7 @@ var _$app_1 = {};
 console.log(
   _$thisIsAFunction_3.name,
   _$ThisIsAClass_2.name,
-  function () { _$thisIsAReference_4 }.toString()
+  _$thisIsAReference_4.name
 )
 
 }());

--- a/test/lazy-order/a.js
+++ b/test/lazy-order/a.js
@@ -1,0 +1,1 @@
+console.log('always')

--- a/test/lazy-order/app.js
+++ b/test/lazy-order/app.js
@@ -1,0 +1,7 @@
+require('./a')
+global.later = function () {
+  require('./b') // should not run immediately
+}
+if (Math.random()>0.5) {
+  require('./c') // should not always run
+}

--- a/test/lazy-order/b.js
+++ b/test/lazy-order/b.js
@@ -1,0 +1,1 @@
+console.log('later')

--- a/test/lazy-order/c.js
+++ b/test/lazy-order/c.js
@@ -1,0 +1,1 @@
+console.log('conditionally')

--- a/test/lazy-order/expected.js
+++ b/test/lazy-order/expected.js
@@ -1,0 +1,25 @@
+(function(){
+var createModuleFactory = function createModuleFactory(t){var e;return function(r){return e||t(e={exports:{},parent:r},e.exports),e.exports}};
+var _$c_4 = createModuleFactory(function (module, exports) {
+console.log('conditionally')
+
+});
+var _$b_3 = createModuleFactory(function (module, exports) {
+console.log('later')
+
+});
+var _$a_1 = {};
+console.log('always')
+
+var _$app_2 = {};
+(function (global){
+_$a_1
+global.later = function () {
+  _$b_3({}) // should not run immediately
+}
+if (Math.random()>0.5) {
+  _$c_4({}) // should not always run
+}
+
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+}());

--- a/test/test.js
+++ b/test/test.js
@@ -18,6 +18,7 @@ var tests = [
   'globals',
   'input-source-map',
   'lazy-cycles',
+  'lazy-order',
   'module-parent',
   'remove-decl',
   'set-exports',


### PR DESCRIPTION
generalise the cyclical dependency machinery to deal with:

```js
function calledLater () {
  require('./side-effect-2')
}
require('./side-effect-1')
```

previously side-effect-2 would be executed before side-effect-1. Now it
will only be executed once `calledLater` is called.

fixes #34