### PR TITLE
Fix lazy exposed modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -436,7 +436,13 @@ function flatten (rows, opts, stream) {
   for (var i = 0; i < rows.length; i++) {
     if (rows[i].expose && !opts.standalone) {
       exposesModules = true
-      outro += '\n' + rows.exposeName + '.m[' + JSON.stringify(rows[i].id) + '] = ' + rows[i][kExportsName] + ';'
+      if (rows[i][kEvaluateOnDemand]) {
+        // If the module is evaluated on demand, using a function, define
+        // a getter so the function will be called.
+        outro += '\nObject.defineProperty(' + rows.exposeName + '.m, ' + JSON.stringify(rows[i].id) + ', { get: function() { return ' + rows[i][kExportsName] + '({}); }});'
+      } else {
+        outro += '\n' + rows.exposeName + '.m[' + JSON.stringify(rows[i].id) + '] = ' + rows[i][kExportsName] + ';'
+      }
     }
 
     var isEntryModule = rows[i].entry && rows[i].hasExports && opts.standalone

--- a/test/expose.js
+++ b/test/expose.js
@@ -10,7 +10,7 @@ test('manual exposed/external modules', function (t) {
   var b1 = browserify({ entries: path.join(__dirname, 'expose/index.js'), standalone: 'expose' })
     .plugin(require.resolve('../plugin'))
     .external(externalModule)
-  
+
   var b2 = browserify()
     .plugin(require.resolve('../plugin'))
     .require(externalModule, { expose: externalModule })
@@ -27,6 +27,46 @@ test('manual exposed/external modules', function (t) {
 
       t.is(nodeOutput, 'localModule /// ' + process.cwd() + '/test/expose/anotherLocalModule.js')
       t.is(withPluginOutput.expose, 'localModule /// /test/expose/anotherLocalModule.js')
+
+      t.end()
+    }))
+  }))
+})
+
+test('manual exposed/external modules with cycles', function (t) {
+  var externalFiles = ['./a.js', './b.js']
+  var externalModules = externalFiles.map(function (file) {
+    return './' + path.relative(process.cwd(), require.resolve('./lazy-expose/' + file))
+  })
+
+  var b1 = browserify({ entries: path.join(__dirname, 'lazy-expose/app.js'), standalone: 'expose' })
+    .plugin(require.resolve('../plugin'))
+    .external(externalModules)
+    .on('error', t.fail)
+
+  var b2 = browserify()
+    .plugin(require.resolve('../plugin'))
+    .require(externalModules.map(function (m) {
+      return {
+        file: m,
+        expose: m
+      }
+    }))
+    .on('error', t.fail)
+
+  b1.bundle().pipe(concat(function (output1) {
+    b2.bundle().pipe(concat(function (output2) {
+      var nodeOutput = require('./lazy-expose/app.js')
+
+      var withPluginOutput = {}
+      var withPlugin = vm.createContext(withPluginOutput)
+
+      vm.runInContext(output2, withPlugin)
+      vm.runInContext(output1, withPlugin)
+
+      var expectedOutput = 'function () {\n  return b()\n}'
+      t.is(nodeOutput, expectedOutput)
+      t.is(withPluginOutput.expose, expectedOutput)
 
       t.end()
     }))

--- a/test/lazy-expose/a.js
+++ b/test/lazy-expose/a.js
@@ -1,0 +1,4 @@
+var b = require('./b')
+module.exports = function () {
+  return b()
+}

--- a/test/lazy-expose/app.js
+++ b/test/lazy-expose/app.js
@@ -1,0 +1,1 @@
+module.exports = require('./a')()

--- a/test/lazy-expose/b.js
+++ b/test/lazy-expose/b.js
@@ -1,0 +1,3 @@
+module.exports = function () {
+  return require('./a').toString()
+}


### PR DESCRIPTION
Lazy modules that were exposed by being external were not being handled correctly. The require function would return the function that needed to be called to return the exported object rather than the exported object itself.

This commit adds lazy modules as getters, so that referencing one calls the function and evaluates the module. It also adds a test case based on the existing "expose" test case.

Fixes #40.