### PR TITLE
Bump ecmaVersion for issues with try {} catch {}

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function parseModule (row, index, rows, opts) {
   // we initialise the scopes and declarations in the first one here, and then collect
   // references in the second.
   var magicString = transformAst(source, {
-    ecmaVersion: 9,
+    ecmaVersion: 10,
     inputFilename: row.sourceFile,
     sourceType: opts.sourceType || 'script'
   }, function (node) {


### PR DESCRIPTION
When using `browser-pack-flat` together with `browserify`, you run into issues inside `acorn` since it finds try/catch blocks without the `(err)` for the exception and the `ecmaVersion` is too low.

Basically, `acorn` throws an error if `ecmaVersion` is lower than 10 https://github.com/acornjs/acorn/blob/9c2cad5c9b51235a1933d45d7b5998849e6f8a7d/acorn/src/statement.js#L352